### PR TITLE
Fix DMS conversion when seconds is supplied

### DIFF
--- a/src/geo/core.cljc
+++ b/src/geo/core.cljc
@@ -524,7 +524,7 @@
       (* (if (re-matches #"(?i)(^-).*|(.*[WS])$" (str s)) -1.0 1.0)
          (cond
            (and degrees minutes seconds)
-           (+ (/ degrees 1) (/ minutes 60) (/ seconds 360))
+           (+ (/ degrees 1) (/ minutes 60) (/ seconds 3600))
            (and degrees minutes)
            (+ (/ degrees 1) (/ minutes 60))
            :else degrees)))


### PR DESCRIPTION
DMS to decimal coordinate conversion should be  d + m/60 + s/3600